### PR TITLE
GenSoftware:  Fix arc-theme installation

### DIFF
--- a/2-GenSoftware.sh
+++ b/2-GenSoftware.sh
@@ -13,6 +13,9 @@ execute () {
 }
 
 execute sudo apt-get install libboost-all-dev curl -y
+
+execute sudo add-apt-repository ppa:noobslab/themes
+execute sudo apt-get update
 execute sudo apt-get install arc-theme
 
 # Install code editor of your choice

--- a/2-GenSoftware.sh
+++ b/2-GenSoftware.sh
@@ -14,9 +14,9 @@ execute () {
 
 execute sudo apt-get install libboost-all-dev curl -y
 
-execute sudo add-apt-repository ppa:noobslab/themes
+execute sudo add-apt-repository ppa:noobslab/themes -y
 execute sudo apt-get update
-execute sudo apt-get install arc-theme
+execute sudo apt-get install arc-theme -y
 
 # Install code editor of your choice
 if [[ ! -n $CIINSTALL ]]; then


### PR DESCRIPTION
Arc-theme is not present in the Ubuntu 16.04 repositories which causes the script to fail on xenial.
This is an initial fix by adding the PPA for the same.

Further things to add:
* [ ] Add arc icons
* [x] Ubuntu 18.04 has these in its main repo itself. Add an if-else case to handle the different OSes
* [x] Tweak Tool is required to change the themes. 
    But 16.04 uses ```unity-tweak-tool``` whereas 18.04 uses ```gnome-tweak-tool```
    This will require the previous mentioned step.
