### PR TITLE
GenSoftware: Change conda install to pip

### DIFF
--- a/1-BasicSetUp.sh
+++ b/1-BasicSetUp.sh
@@ -120,7 +120,7 @@ execute /opt/anaconda3/bin/conda install libgcc -y
 execute /opt/anaconda3/bin/conda create --name py27 python=2.7 numpy scipy matplotlib scikit-learn scikit-image jupyter notebook pandas h5py jupyterlab cython -y
 execute /opt/anaconda3/bin/conda create --name py36 python=3.6 numpy scipy matplotlib scikit-learn scikit-image jupyter notebook pandas h5py jupyterlab cython line_profiler -y
 execute /opt/anaconda3/bin/pip install numpy scipy matplotlib scikit-learn scikit-image jupyter notebook pandas h5py cython
-execute /opt/anaconda3/bin/conda install line_profiler msgpack
+execute /opt/anaconda3/bin/pip install line_profiler msgpack
 sed -i.bak "/anaconda3/d" ~/.zshrc
 
 execute /opt/anaconda3/bin/pip install autopep8 scdl org-e youtube-dl jupyterlab

--- a/1-BasicSetUp.sh
+++ b/1-BasicSetUp.sh
@@ -121,7 +121,7 @@ execute /opt/anaconda3/bin/conda create --name py27 python=2.7 numpy scipy matpl
 execute /opt/anaconda3/bin/conda create --name py36 python=3.6 numpy scipy matplotlib scikit-learn scikit-image jupyter notebook pandas h5py jupyterlab cython line_profiler -y
 execute /opt/anaconda3/bin/pip install numpy scipy matplotlib scikit-learn scikit-image jupyter notebook pandas h5py cython
 execute /opt/anaconda3/bin/pip install msgpack
-execute /opt/anaconda3/bin/conda install line_profiler
+execute /opt/anaconda3/bin/conda install line_profiler -y
 sed -i.bak "/anaconda3/d" ~/.zshrc
 
 execute /opt/anaconda3/bin/pip install autopep8 scdl org-e youtube-dl jupyterlab

--- a/1-BasicSetUp.sh
+++ b/1-BasicSetUp.sh
@@ -120,7 +120,8 @@ execute /opt/anaconda3/bin/conda install libgcc -y
 execute /opt/anaconda3/bin/conda create --name py27 python=2.7 numpy scipy matplotlib scikit-learn scikit-image jupyter notebook pandas h5py jupyterlab cython -y
 execute /opt/anaconda3/bin/conda create --name py36 python=3.6 numpy scipy matplotlib scikit-learn scikit-image jupyter notebook pandas h5py jupyterlab cython line_profiler -y
 execute /opt/anaconda3/bin/pip install numpy scipy matplotlib scikit-learn scikit-image jupyter notebook pandas h5py cython
-execute /opt/anaconda3/bin/pip install line_profiler msgpack
+execute /opt/anaconda3/bin/pip install msgpack
+execute /opt/anaconda3/bin/conda install line_profiler
 sed -i.bak "/anaconda3/d" ~/.zshrc
 
 execute /opt/anaconda3/bin/pip install autopep8 scdl org-e youtube-dl jupyterlab


### PR DESCRIPTION
`conda install` failing for some reason. Trying out `pip` in place of that. Also makes it consistent with the installation in the previous line