### PR TITLE
ML-Build: Added flag for NVML header files

### DIFF
--- a/3-ML-Build.sh
+++ b/3-ML-Build.sh
@@ -108,8 +108,7 @@ elif test "$tempvar" = "s"; then
     
     cd tensorflow
 #     Checkout the latest release candidate, as it should be relatively stable
-#     git checkout $(git tag --sort=-creatordate | egrep -v '-' | head -1)
-    git checkout master
+    git checkout $(git tag --sort=-creatordate | egrep -v '-' | head -1)
     
     if [[ ! -n $CIINSTALL ]]; then
         read -p "Starting Configuration process. Be alert for the queries it will throw at you. Press [Enter]" temp
@@ -127,7 +126,7 @@ elif test "$tempvar" = "s"; then
     bazel build --config=opt${MKL_OPTIM}${GPU_OPTIM} //tensorflow/tools/pip_package:build_pip_package
     cd ../
     
-    execute bazel-bin/tensorflow/tools/pip_package/build_pip_package --nightly_flag /tmp/tensorflow_pkg
+    execute bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
     execute $PIP /tmp/tensorflow_pkg/*.whl --force-reinstall
     cd ../
 

--- a/3-ML-Build.sh
+++ b/3-ML-Build.sh
@@ -106,9 +106,10 @@ elif test "$tempvar" = "s"; then
     )
     fi
     
-    # Checkout the latest release candidate, as it should be relatively stable
     cd tensorflow
-    git checkout $(git tag --sort=-creatordate | egrep -v '-' | head -1)
+#     Checkout the latest release candidate, as it should be relatively stable
+#     git checkout $(git tag --sort=-creatordate | egrep -v '-' | head -1)
+    git checkout master
     
     if [[ ! -n $CIINSTALL ]]; then
         read -p "Starting Configuration process. Be alert for the queries it will throw at you. Press [Enter]" temp
@@ -126,7 +127,7 @@ elif test "$tempvar" = "s"; then
     bazel build --config=opt${MKL_OPTIM}${GPU_OPTIM} //tensorflow/tools/pip_package:build_pip_package
     cd ../
     
-    execute bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
+    execute bazel-bin/tensorflow/tools/pip_package/build_pip_package --nightly_flag /tmp/tensorflow_pkg
     execute $PIP /tmp/tensorflow_pkg/*.whl --force-reinstall
     cd ../
 

--- a/3-ML-Build.sh
+++ b/3-ML-Build.sh
@@ -60,18 +60,18 @@ else
     echo "Not adding Cuda to the PATH"
 fi
 
-
-spatialPrint "Installing nvtop"
-execute sudo apt-get install cmake libncurses5-dev git -y
-if [[ ! -d "nvtop" ]]; then
-    execute git clone --quiet https://github.com/Syllo/nvtop.git
+if which nvcc > /dev/null; then
+    spatialPrint "Installing nvtop"
+    execute sudo apt-get install cmake libncurses5-dev git -y
+    if [[ ! -d "nvtop" ]]; then
+        execute git clone --quiet https://github.com/Syllo/nvtop.git
+    fi
+    execute mkdir -p nvtop/build
+    cd nvtop/build
+    execute cmake -DCMAKE_BUILD_TYPE=Optimized -DNVML_RETRIEVE_HEADER_ONLINE=True ..
+    execute make
+    execute sudo make install
 fi
-execute mkdir -p nvtop/build
-cd nvtop/build
-execute cmake -DCMAKE_BUILD_TYPE=Optimized -DNVML_RETRIEVE_HEADER_ONLINE=True ..
-execute make
-execute sudo make install
-
 
 execute $PIP numpy
 execute sudo apt-get install -y build-essential cmake pkg-config openjdk-8-jdk

--- a/3-ML-Build.sh
+++ b/3-ML-Build.sh
@@ -68,7 +68,7 @@ if [[ ! -d "nvtop" ]]; then
 fi
 execute mkdir -p nvtop/build
 cd nvtop/build
-execute cmake -DCMAKE_BUILD_TYPE=Optimized ..
+execute cmake -DCMAKE_BUILD_TYPE=Optimized -DNVML_RETRIEVE_HEADER_ONLINE=True ..
 execute make
 execute sudo make install
 


### PR DESCRIPTION
Travis build is failing due to the following error
`Could NOT find NVML (missing: NVML_INCLUDE_DIRS NVML_LIBRARIES)`

Trying out the fix from the `nvtop` readme: [https://github.com/Syllo/nvtop#nvtop-build](https://github.com/Syllo/nvtop#nvtop-build)

I haven't ran this script on my laptop so not sure if this actually required or not