### PR TITLE
Remove extra PPA from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ matrix:
       python: 3.6
 before_install:
     - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse"
-    - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
     - sudo apt-get update -qq
     - sudo apt-get install -y software-properties-common
     - sudo apt-get install -qq build-essential curl g++ python-dev python3-dev python-setuptools python3-setuptools


### PR DESCRIPTION
The PPA seems to be missing or down from quite some time for Ubuntu 18.04
Testing to see if removing the PPA works since it doesn't seem like we are explicitly installing any packages from this PPA