### PR TITLE
Install latest Zsh+Zim

### DIFF
--- a/1-BasicSetUp.sh
+++ b/1-BasicSetUp.sh
@@ -69,13 +69,8 @@ fi
 spatialPrint "Setting up Zsh + Zim now"
 execute sudo apt-get install zsh -y
 sudo mkdir -p /opt/.zsh/ && sudo chmod ugo+w /opt/.zsh/
-git clone --recursive --quiet --branch zsh-5.2 https://github.com/zimfw/zimfw.git /opt/.zsh/zim
-ln -s /opt/.zsh/zim/ ~/.zim
-ln -s /opt/.zsh/zim/templates/zimrc ~/.zimrc
-ln -s /opt/.zsh/zim/templates/zlogin ~/.zlogin
-ln -s /opt/.zsh/zim/templates/zshrc ~/.zshrc
-git clone https://github.com/zsh-users/zsh-autosuggestions /opt/.zsh/zsh-autosuggestions
-echo "source /opt/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc
+export ZIM_HOME=/opt/.zsh/zim
+curl -fsSL https://raw.githubusercontent.com/zimfw/install/master/install.zsh | zsh
 # Change default shell to zsh
 command -v zsh | sudo tee -a /etc/shells
 sudo chsh -s "$(command -v zsh)" "${USER}"

--- a/1-BasicSetUp.sh
+++ b/1-BasicSetUp.sh
@@ -67,7 +67,16 @@ if [[ -d $zsh_folder ]];then
 fi
 
 spatialPrint "Setting up Zsh + Zim now"
-execute sudo apt-get install zsh -y
+# Ubuntu 16.04 has older zsh in repository
+if [[ $(cat /etc/os-release | grep "VERSION_ID" | grep -o -E '[0-9][0-9]' | head -n 1) -le 16 ]]; then
+    wget https://gist.githubusercontent.com/rsnk96/87229bd910e01f2ee7c35f96d7cb2f6c/raw/f068812ebd711ed01ebc4c128c8624730ab0dc81/build-zsh.sh -O extras/build-zsh.sh
+    # Install latest zsh release
+    sed -i '/cd zsh/a git checkout $(git tag | tail -1)' extras/build-zsh.sh
+    bash extras/build-zsh.sh
+else
+    execute sudo apt-get install zsh -y
+fi
+
 sudo mkdir -p /opt/.zsh/ && sudo chmod ugo+w /opt/.zsh/
 export ZIM_HOME=/opt/.zsh/zim
 curl -fsSL https://raw.githubusercontent.com/zimfw/install/master/install.zsh | zsh

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Additional scripts to built libraries from source:
         ```bash
         cd ~
         export NEW_USER=<username_of_new_user>
-        sudo cp -r /opt/.zsh/zim/ /home/$NEW_USER/.zim
         sudo cp /opt/.zsh/bash_aliases /home/$NEW_USER/.bash_aliases
-        sudo cp /opt/.zsh/zim/templates/zimrc /home/$NEW_USER/.zimrc
-        sudo cp /opt/.zsh/zim/templates/zlogin /home/$NEW_USER/.zlogin
+        sudo cp -r ~/.zim/ /home/$NEW_USER/.zim
+        sudo cp ~/.zimrc /home/$NEW_USER/.zimrc
+        sudo cp ~/.zlogin /home/$NEW_USER/.zlogin
         sudo cp ~/.zshrc /home/$NEW_USER/.zshrc
+        sudo cp ~/.zshenv /home/$NEW_USER/.zshenv
 
         sudo cp ~/.xbindkeysrc /home/$NEW_USER
         sudo mkdir -p /home/$NEW_USER/.config/tilda


### PR DESCRIPTION
Closes #59 
https://github.com/zimfw/zimfw

TODO:
- [x] Actually test if this is working :sweat_smile: (Probably in VirtualBox)
- [x] Install latest `zsh` for Ubuntu 16.04 (Newer Zim requires Zsh >= 5.2)
- [x] Update instructions for multiple users