### PR TITLE
Fix OpenCV build on Anaconda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
       script:
       - ./Build-OpenCV.sh
       - ffmpeg -version
-      - gdb --ex='set confirm on' -ex=run -ex=bt -ex=quit --args python3 extras/opencv_test.py
+      - python3 extras/opencv_test.py
       python: 3.7
 
     - name: xenial-ml
@@ -48,7 +48,7 @@ jobs:
       - hash -r  # To reload env vars like PATH
       - ./Build-OpenCV.sh
       - ffmpeg -version
-      - gdb --ex='set confirm on' -ex=run -ex=bt -ex=quit --args python extras/opencv_test.py
+      - python extras/opencv_test.py
       python: 3.7
 
     - name: bionic-basic
@@ -65,7 +65,7 @@ jobs:
       script:
       - ./Build-OpenCV.sh
       - ffmpeg -version
-      - gdb --ex='set confirm on' -ex=run -ex=bt -ex=quit --args python3 extras/opencv_test.py
+      - python3 extras/opencv_test.py
       python: 3.7
 
     - name: bionic-ml
@@ -86,7 +86,7 @@ jobs:
       - hash -r  # To reload env vars like PATH
       - ./Build-OpenCV.sh
       - ffmpeg -version
-      - gdb --ex='set confirm on' -ex=run -ex=bt -ex=quit --args python extras/opencv_test.py
+      - python extras/opencv_test.py
       python: 3.7
 
 before_install:


### PR DESCRIPTION
Noticed while looking at Travis build of latest master
```
Traceback (most recent call last):
  File "extras/opencv_test.py", line 1, in <module>
    import cv2
  File "/opt/anaconda3/lib/python3.7/site-packages/cv2/__init__.py", line 96, in <module>
    bootstrap()
  File "/opt/anaconda3/lib/python3.7/site-packages/cv2/__init__.py", line 86, in bootstrap
    import cv2
ImportError: /opt/anaconda3/bin/../lib/libgio-2.0.so.0: undefined symbol: g_ref_count_inc
```

For some reason the build is not shown as failed which needs to be looked into